### PR TITLE
🤖 Add Ace editor and highlightjs languages to config.json

### DIFF
--- a/config.json
+++ b/config.json
@@ -14,8 +14,8 @@
   "online_editor": {
     "indent_style": "space",
     "indent_size": 4,
-    "ace_editor_language": "shen",
-    "highlightjs_language": "shen"
+    "ace_editor_language": "text",
+    "highlightjs_language": "text"
   },
   "ignore_pattern": "[Ee]xample",
   "solution_pattern": "[Ee]xample",

--- a/config.json
+++ b/config.json
@@ -13,7 +13,7 @@
   "version": 3,
   "online_editor": {
     "indent_style": "space",
-    "indent_size": 4,
+    "indent_size": 2,
     "ace_editor_language": "text",
     "highlightjs_language": "text"
   },

--- a/config.json
+++ b/config.json
@@ -13,7 +13,9 @@
   "version": 3,
   "online_editor": {
     "indent_style": "space",
-    "indent_size": 4
+    "indent_size": 4,
+    "ace_editor_language": "shen",
+    "highlightjs_language": "shen"
   },
   "ignore_pattern": "[Ee]xample",
   "solution_pattern": "[Ee]xample",
@@ -48,5 +50,11 @@
   },
   "concepts": [],
   "key_features": [],
-  "tags": ["paradigm/functional", "paradigm/logic", "typing/static", "typing/dynamic", "execution_mode/interpreted"]
+  "tags": [
+    "paradigm/functional",
+    "paradigm/logic",
+    "typing/static",
+    "typing/dynamic",
+    "execution_mode/interpreted"
+  ]
 }


### PR DESCRIPTION
This PR adds adds two new keys to the `online_editor` property in the `config.json` files:

1. `ace_editor_language`: the language identifier for the Ace editor that is used to edit code on the website
2. `highlightjs_language`: the language identifier for Highlight.js which is used to highlight code on the website

For more information, see https://github.com/exercism/docs/pull/124/files

## Maintainer TODO list

We've pre-populated the values for the two new keys with the track's slug, which is probably the correct value for most tracks. Please check these values are correct for your track:

- [x] The `ace_editor_language` value is correct. See the [full list of identifiers](https://github.com/ajaxorg/ace/tree/master/lib/ace/mode) (filenames, not directories).
- [x] The `highlightjs_language` value is correct. See the [full list of identifiers](https://github.com/highlightjs/highlight.js/blob/main/SUPPORTED_LANGUAGES.md)

## Tracking

https://github.com/exercism/v3-launch/issues/32
