### PR TITLE
🤖 Simplify `hello-world` stub

### DIFF
--- a/exercises/practice/hello-world/hello-world.shen
+++ b/exercises/practice/hello-world/hello-world.shen
@@ -1,0 +1,5 @@
+(package hello-world [hello]
+
+(define hello
+  {--> string}
+  -> "Goodbye, Mars!"))


### PR DESCRIPTION
Simplify the `hello-world` exercise's stub. The goal of this is to make things easier for students to get started and to introduce as little syntax as possible.

See https://github.com/exercism/v3-launch/issues/46